### PR TITLE
[GT de JSR] PJR-000 - Enrollments - v2.2.0-rc.1: Adicao de descrição ao campo excludeCredentials

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1770,6 +1770,8 @@ components:
               description: Timeout, em milissegundos, para registro da credencial FIDO2.
             excludeCredentials:
               type: array
+              description: |  
+                Lista de IDs de credenciais já existentes para este usuário e autenticador. É utilizado para evitar a criação de múltiplas credenciais para o mesmo usuário em mesmo autenticador. Caso seja enviado, a iniciadora pode rejeitar o registro de uma das credenciais já existentes no dispositivo, ou seguir com a criação, substituindo ou não o vínculo já existente.
               items:
                 $ref: '#/components/schemas/FidoPublicKeyCredentialDescriptor'
             authenticatorSelection:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,7 @@ info:
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
     Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.1.0
+  version: 2.2.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto
Durante análise do FAQ da versão 2.1.0, realizado pela DTO, foi identificada a possibilidade de transportar uma das perguntas para a especificação da API, garantindo maior visibilidade para o tratamento que deve ser aplicado ao campo.

### Descrição
Na mensagem de resposta de sucesso do endpoint POST /enrollments/{enrollmentId}/fido-registration-options, adicionar uma descrição ao campo /data/excludeCredentials:
Lista de IDs de credenciais já existentes para este usuário e autenticador. É utilizado para evitar a criação de múltiplas credenciais para o mesmo usuário em mesmo autenticador. Caso seja enviado, a iniciadora pode rejeitar o registro de uma das credenciais já existentes no dispositivo, ou seguir com a criação, substituindo ou não o vínculo já existente.
Remover da FAQ a pergunta abaixo, relacionada ao item:
Pergunta: A iniciadora de transação de pagamento (ITP) pode ignorar o valor retornado no campo excludeCredentials na resposta do endpoint /fido-registration-options?
Resposta: Sim, a iniciadora pode optar por ignorar o valor retornado no campo excludeCredentials. Esse campo é utilizado para evitar a criação de múltiplas credenciais para a mesma conta em um único autenticador. Caso seja enviado, a iniciadora pode rejeitar o registro se uma das credenciais já existir no dispositivo, ou seguir com a criação e substituir ou não o vínculo já existente. Embora opcional no primeiro registro, seu uso é recomendado ao criar um novo vínculo de conta no mesmo dispositivo. Para mais detalhes, consulte a especificação oficial: Web Authentication: An API for accessing Public Key Credentials - Level 2.
