### PR TITLE
[Squad JSR] PJR108 - Enrollments - 2.2.0-rc.2: Proposta para ajustar a descrição do corpo de requisição do endpoint de autorização de consentimentos​

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,7 @@ info:
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
     Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -528,7 +528,7 @@ paths:
         - $ref: '#/components/parameters/x-bcb-nfc'
       requestBody:
         required: true
-        description: Payload para autorização de consentimento a partir de um vínculo de conta.
+        description: Payload para autorização de um consentimento através do dispositivo vinculado.
         content:
           application/jwt:
             schema:


### PR DESCRIPTION
### Contexto

Durante análise da especificação, foi identificado pela DTO uma inconsistência na descrição da mensagem de requisição do endpoint de autorização de consentimentos para pagamentos imediatos e agendamentos únicos ou recorrentes.​

Sendo assim, GT e DTO entendem como necessário alterar a descrição, corrigindo o texto presente


### Descrição

Alterar a descrição da mensagem de requisição do endpoint POST /consents/{consentId}/authorise:​

DE: Payload para criação de vínculo de conta.​
PARA: Payload para autorização de um consentimento através do dispositivo vinculado.