### PR TITLE
[Squad JSR] PJR112 - Enrollments - 2.2.0-rc.2: API Vínculo de dispositivo – Proposta para alterar a descrição do sinal de risco deviceId​

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,7 @@ info:
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
     Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto

Durante agenda realizada no dia 23/07/25, foi sugerido por membros da Squad um ajuste na descrição do campo deviceId, contemplando a sua geração através de mecanismos diferentes do que está sendo solicitado na descrição atual.

Squad e DTO concordaram com a mudança e, decorrente disso, faz-se necessário realizar o ajuste na especificação técnica

### Descrição

Na mensagem de requisição do endpoint POST ​/enrollments​/{enrollmentId}​/risk-signals e na mensagem de requisição dos endpoints POST /consents/{consentId}/authorise e POST /recurring-consents/{recurringConsentId}/authorise:

Ajustar a descrição do campo “deviceId”:

DE:
ID único do dispositivo gerado pela plataforma.
Utiliza-se a propriedade do sistema que identifica a combinação de usuário logado, chave de assinatura do aplicativo e dispositivo.
[Android] Informação obtida através do link.
[iOS] Informação obtida através do link.

PARA: 
ID único do dispositivo gerado pela plataforma.
A geração deve utilizar-se da propriedade do sistema que identifica a combinação de usuário logado, chave de assinatura do aplicativo e dispositivo ou de algoritmos heurísticos capazes de criar um identificador único para o dispositivo.
[Android] Informação obtida através do link.
[iOS] Informação obtida através do link.