### PR TITLE
[Squad JSR] PJR111 - Enrollments - 2.2.0-rc.2: API Vínculo de dispositivo – Proposta para ajustar o endpoint que obtem os parametros de autenticacao para incluir consentimentos de longa duração

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,7 @@ info:
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
     Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -396,26 +396,47 @@ paths:
                   type: object
                   description: |
                     Objeto que contém as informações sobre a Relying Party e a plataforma sobre a qual o usuário está utilizando o serviço da iniciadora para utilização de FIDO2.
-                  required:
-                    - rp
-                    - platform
-                    - consentId
-                  properties:
-                    rp:
-                      type: string
-                      description: Identificador único da Relying Party, que corresponde ao valor do CN do certificado de transporte da iniciadora.
-                    platform:
-                      type: string
-                      description: |
-                        Indica a plataforma em que o usuário criará a nova credencial FIDO2. 
-                        Este campo permite que o servidor FIDO inclua extensões de acordo com a plataforma utilizada.
-                      enum:
-                        - ANDROID
-                        - BROWSER
-                        - CROSS_PLATFORM
-                        - IOS
-                    consentId:
-                      $ref: '#/components/schemas/consentId'
+                  oneOf:
+                    - required:
+                      - rp
+                      - platform
+                      - consentId
+                      properties:
+                        rp:
+                          type: string
+                          description: Identificador único da Relying Party, que corresponde ao valor do CN do certificado de transporte da iniciadora.
+                        platform:
+                          type: string
+                          description: |
+                            Indica a plataforma em que o usuário criará a nova credencial FIDO2. 
+                            Este campo permite que o servidor FIDO inclua extensões de acordo com a plataforma utilizada.
+                          enum:
+                            - ANDROID
+                            - BROWSER
+                            - CROSS_PLATFORM
+                            - IOS
+                        consentId:
+                          $ref: '#/components/schemas/consentId'
+                    - required:
+                      - rp
+                      - platform
+                      - recurringConsentId
+                      properties:
+                        rp:
+                          type: string
+                          description: Identificador único da Relying Party, que corresponde ao valor do CN do certificado de transporte da iniciadora.
+                        platform:
+                          type: string
+                          description: |
+                            Indica a plataforma em que o usuário criará a nova credencial FIDO2. 
+                            Este campo permite que o servidor FIDO inclua extensões de acordo com a plataforma utilizada.
+                          enum:
+                            - ANDROID
+                            - BROWSER
+                            - CROSS_PLATFORM
+                            - IOS
+                        recurringConsentId:
+                          $ref: '#/components/schemas/recurringConsentIdSignOptions'
       responses:
         '201':
           $ref: '#/components/responses/201EnrollmentFidoSignOptions'
@@ -1601,6 +1622,20 @@ components:
         - o namespace(urn)
         - o identificador associado ao namespace da instituição detentora de conta (bancoex)
         - o identificador específico dentro do namespace (C1DD33123).
+        Informações mais detalhadas sobre a construção de namespaces devem ser consultadas na [RFC8141](https://tools.ietf.org/html/rfc8141).
+    recurringConsentIdSignOptions:
+      type: string
+      pattern: '^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{0,31}:[a-zA-Z0-9()+,\-.:=@;$_!*''%\/?#]+$'
+      maxLength: 256
+      description: |
+        Identificador único do consentimento de longa duração criado para a iniciação de pagamento solicitada. Deverá ser um URN - Uniform Resource Name. 
+        Um URN, conforme definido na [RFC8141](https://tools.ietf.org/html/rfc8141) é um Uniform Resource 
+        Identifier - URI - que é atribuído sob o URI scheme "urn" e um namespace URN específico, com a intenção de que o URN 
+        seja um identificador de recurso persistente e independente da localização. 
+        Considerando a string urn:bancoex:C1DD33123 como exemplo para `recurringConsentId` temos:
+        - o namespace(urn)
+        - o identificador associado ao namespace da instituição transmissora (bancoex)
+        - o identificador específico dentro do namespace (C1DD33123).  
         Informações mais detalhadas sobre a construção de namespaces devem ser consultadas na [RFC8141](https://tools.ietf.org/html/rfc8141).
     consentId:
       type: string


### PR DESCRIPTION
### Contexto

Foi solicitado pelo regulador que o produto JSR pudesse ser capaz de autorizar também consentimentos do produto Pix Automático.​

Squad e DTO concordam e, devido a isso, sugerem ajustes no endpoint responsável por gerar as opções de autenticação disponíveis para a credencial FIDO2.


### Descrição

Ajustar o corpo de requisição do endpoint POST /enrollments/{enrollmentId}/fido-sign-options, contemplando o consentimento recorrente:​

DE:​
{​
 “data”: {​
 “rp”: “string”,​
 “platform”: “string”,​
 “consentId”: “string”​
 }​
}​

PARA:​
{​
 “data”: {​
 “rp”: “string”,​
 “platform”: “string”,​
 “oneOf”: [​
 {​
 “consentId”: “string”​
 },​
 {​
 “recurringConsentId”: “string”​
 }​
 ]​
 }



