### PR TITLE
[Squad JSR] PJR116 - Enrollments - 2.2.0-rc.2: Jornada Otimizada – Proposta para adicionar objeto journey na API Vínculo de dispositivo  

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1074,6 +1074,27 @@ components:
               description: Tipo do documento de identificação oficial do titular pessoa jurídica.
               example: CNPJ
               pattern: '^[A-Z]{4}$'
+    EnrollmentJourney:
+      type: object
+      required:
+        - isLinked
+        - linkId
+      description: | 
+        Informações adicionais sobre o contexto de Jornada Otimizada.  
+        [RESTRIÇÃO] Objeto de envio obrigatório quando o usuário manifestar consentimento para compartilhamento de saldo através da Jornada Otimizada, independente do status do consentimento de dados”
+      properties:
+        isLinked:
+          type: boolean
+          example: false
+          description: |
+            Campo para identificação de consentimento iniciado em Jornada Otimizada.
+        linkId:
+          type: string
+          pattern: ^urn:[a-zA-Z0-9][a-zA-Z0-9-]{0,31}:[a-zA-Z0-9()+,\-.:=@;$_!*'%\/?#]+$
+          maxLength: 256
+          example: urn:bancoex:C1DD331237
+          description: |
+            Identificador do consentimento de dados ao qual este consentimento está vinculado.
     CreateEnrollment:
       type: object
       required:
@@ -1097,6 +1118,8 @@ components:
               $ref: '#/components/schemas/BusinessEntity'
             debtorAccount:
               $ref: '#/components/schemas/DebtorAccount'
+            journey:
+              $ref: '#/components/schemas/EnrollmentJourney'
             enrollmentName:
               description: |
                 [Restrição] Deve ser preenchido sempre que o usuário pagador inserir alguma informação no nome do vínculo/dispositivo tanto no iniciador como no detentor de conta
@@ -2127,6 +2150,8 @@ components:
               $ref: '#/components/schemas/BusinessEntity'
             debtorAccount:
               $ref: '#/components/schemas/DebtorAccount'
+            journey:
+              $ref: '#/components/schemas/EnrollmentJourney'
             enrollmentName:
               description: |
                 [Restrição] Deve ser preenchido sempre que o usuário pagador inserir alguma informação no nome do vínculo/dispositivo tanto no iniciador como no detentor de conta
@@ -2204,6 +2229,8 @@ components:
                     As informações quanto à conta de origem do pagador poderão ser trazidas no vínculo para a detentora, caso a iniciadora tenha coletado essas informações do cliente. Do contrário, será coletada na detentora e trazida para a iniciadora como resposta à criação do vínculo. 
                     
                     [ Restrição ] Deve obrigatoriamente ser preenchido nos status AWAITING_ENROLLMENT, AUTHORISED e REVOKED e não deve ser alterado.
+            journey:
+              $ref: '#/components/schemas/EnrollmentJourney'
             cancellation:
               type: object
               required:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,7 @@ info:
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
     Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto

A Jornada Otimizada exige a JSR  
possibilidade de vincular um   
vínculo ou consentimento de   
pagamento com   
consentimentos de dados em   
uma mesma cadeia, sendo   
necessária a visibilidade de   
quais consentimentos estão   
atrelados  
▪ Para suportar essa   
necessidade, a partir de   
agenda conjunta com os GTs  
Dados do cliente, Serviços, UX   
e Segurança, propõe-se a   
inclusão do objeto journey,   
que permite indicar se o   
consentimento foi gerado a   
partir da Jornada Otimizada e   
deve ter apenas o escopo   
permitido para esta jornada 

### Descrição

Adicionar o objeto journey e os campos isLinked e linkId