### PR TITLE
[Squad JSR] PJR118 - Enrollments - 2.2.0-rc.2: API Vínculo de dispositivo – Proposta para adicionar erro relacionado a falta de permissão necessária para autenticação do usuário e o tipo de consentimento criado

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -862,6 +862,7 @@ components:
                   - PARAMETRO_NAO_INFORMADO
                   - PARAMETRO_INVALIDO
                   - ERRO_IDEMPOTENCIA
+                  - PERMISSAO_INVALIDA_VINCULO_CONSENTIMENTO 
                 example: STATUS_VINCULO_INVALIDO
                 description: |
                   Códigos de erros previstos:
@@ -871,6 +872,7 @@ components:
                   - PARAMETRO_NAO_INFORMADO: Parâmetro não informado.
                   - PARAMETRO_INVALIDO: Parâmetro inválido.
                   - ERRO_IDEMPOTENCIA: Erro idempotência.
+                  - PERMISSAO_INVALIDA_VINCULO_CONSENTIMENTO: A permissão definida no vínculo não é válida para o tipo de consentimento informado
               title:
                 type: string
                 maxLength: 255
@@ -884,6 +886,7 @@ components:
                   - PARAMETRO_NAO_INFORMADO: Parâmetro não informado.
                   - PARAMETRO_INVALIDO: Parâmetro inválido.
                   - ERRO_IDEMPOTENCIA: Erro idempotência.
+                  - PERMISSAO_INVALIDA_VINCULO_CONSENTIMENTO: A permissão definida no vínculo não é válida para o tipo de consentimento informado
               detail:
                 type: string
                 maxLength: 2048
@@ -897,6 +900,7 @@ components:
                   - PARAMETRO_NAO_INFORMADO: Parâmetro [nome_campo] obrigatório não informado.
                   - PARAMETRO_INVALIDO: Parâmetro [nome_campo] não obedece as regras de formatação esperadas.
                   - ERRO_IDEMPOTENCIA: Conteúdo da mensagem (claim data) diverge do conteúdo associado a esta chave de idempotência (x-idempotency-key).
+                  - PERMISSAO_INVALIDA_VINCULO_CONSENTIMENTO: A permissão definida no vínculo não é válida para o tipo de consentimento informado.
         meta:
           $ref: '#/components/schemas/Meta'
     422ResponseErrorFidoRegistration:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,7 @@ info:
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
     Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto
▪ Foi adicionada a possibilidade de   
autorizar um consentimento de Pix   
Automático através da API Vínculo de   
dispositivo  
▪ Para permitir essa operação, foram   
realizadas algumas alterações na API,   
entre elas, a adição de uma nova   
permission, a   
“RECURRING_PAYMENTS_INITIATE”  
▪ Para evitar frustrações do cliente,   
Squad e DTO concordam que, caso o   
vínculo criado não possua a permission  
necessária para autorizar um   
consentimento, este precisa ser   
impedido de prosseguir na jornada o   
quanto antes  
▪ Sendo assim, faz-se necessária a adição   
de um novo erro síncrono no endpoint  
responsável por obter os parâmetros de   
autenticação (fido-sign-options),   
responsável por ecoar a falta de   
permissão associada ao vínculo para   
autorizar o tipo de consentimento   
criado  

### Descrição

▪ Na resposta de erro HTTP 422 do endpoint POST /enrollments/{enrollmentId}/fido-sign-options:  
– Adicionar um novo item ao domínio do campo “data.errors.code”:  
▫ PERMISSAO_INVALIDA_VINCULO_CONSENTIMENTO  
– Adicionar um novo item a lista presente na descrição dos campos “data.errors.code”, “data.errors.title” e   
“data.errors.detail” :  
▫ PERMISSAO_INVALIDA_VINCULO_CONSENTIMENTO: A permissão definida no vínculo não é válida para   
o tipo de consentimento informado.
