### PR TITLE
[Squad JSR] PJR117 - Enrollments - 2.2.0-rc.2: API Vínculo de dispositivo – Proposta para definir a relação entre os limites dos produtos JSR e Pix Automático

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10,8 +10,18 @@ info:
     Durante o cadastro do cliente (DCR/DCM), o software statement assertion possui um atributo nomeado software_origin_uris. 
     Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
     Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
-    Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras
-  version: 2.2.0-rc.1
+    Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras.
+
+    ## Sobre os limites do dispositivo vinculado no Pix Automático
+
+    Existem alguns limites que estão envolvidos durante o processo de autorização de um consentimento e o envio dos pagamentos, seja do inicial avulso ou das recorrências, para Pix Automático. Os limites envolvidos e o tratamento esperado pela instituição detentora são:  
+    - Limite diário do vínculo: Deve ser considerado apenas durante o pagamento inicial avulso e não deve ser considerado para pagamentos que representem as recorrências de Pix Automático. 
+    - Limite por transação do vínculo: Deve ser considerado apenas durante o pagamento inicial avulso e não deve ser considerado para pagamentos que representem as recorrências de Pix Automático.   
+    
+    Considerando que a falha no pagamento inicial avulso não implica em rejeite síncrono do consentimento de Pix Automático, problemas de limite e/ou saldo não devem impedir a criação ou autorização do consentimento.   
+    O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo de validação durante a autorização do consentimento através desta API.   
+    Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no consentimento de Pix Automático.
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto

Foi solicitado pelo regulador que   
o produto JSR pudesse ser capaz   
de autorizar também   
consentimentos do produto Pix   
Automático  
▪ Diante disso, faz-se necessário   
definir qual o comportamento a   
ser adotado para os diferentes   
tipos de limites existentes entre a   
Jornada sem Redirecionamento,   
Pix Cobrança e Pix Automático  
▪ Essa proposta visa definir esse   
comportamento, contemplando   
as orientações presentes na  
resposta fornecida pelo DENOR ao   
e-mail de consulta sobre o tema   
enviado pelo Squad 

### Descrição

Adicionar um novo item ao header da API Vínculo de dispositivo:  
– Tópico: Sobre os limites do dispositivo vinculado no Pix Automático  
– Conteúdo:  
“Existem alguns limites que estão envolvidos durante o processo de autorização de um   
consentimento e o envio dos pagamentos, seja do inicial avulso ou das recorrências, para   
Pix Automático. Os limites envolvidos e o tratamento esperado pela instituição detentora   
são:  
- Limite diário do vínculo: Deve ser considerado apenas durante o pagamento inicial   
avulso e não deve ser considerado para pagamentos que representem as recorrências de Pix   
Automático.   
- Limite por transação do vínculo: Deve ser considerado apenas durante o pagamento   
inicial avulso e não deve ser considerado para pagamentos que representem as recorrências   
de Pix Automático.  
Considerando que a falha no pagamento inicial avulso não implica em rejeite síncrono do   
consentimento de Pix Automático, problemas de limite e/ou saldo não devem impedir a   
criação ou autorização do consentimento.   
O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo   
de validação durante a autorização do consentimento através desta API.   
Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no   
consentimento de Pix Automático.”