### PR TITLE
[Squad JSR] PJR139 - Enrollments - 2.2.0: API Vínculo de dispositivo – Proposta para adicionar o erro ORIGEM_FIDO_INVALIDA no endpoint dedicado a autorização de consentimentos recorrentes

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1172,6 +1172,7 @@ components:
                 enum:
                   - STATUS_VINCULO_INVALIDO
                   - STATUS_CONSENTIMENTO_INVALIDO
+                  - ORIGEM_FIDO_INVALIDA
                   - RISCO
                   - FALTAM_SINAIS_OBRIGATORIOS_DA_PLATAFORMA
                   - CONTA_DEBITO_DIVERGENTE_CONSENTIMENTO_VINCULO
@@ -1184,6 +1185,7 @@ components:
 
                   - STATUS_VINCULO_INVALIDO: O vínculo de conta não possui status AUTHORISED.
                   - STATUS_CONSENTIMENTO_INVALIDO: O consentimento de pagamentos não possui status AWAITING_AUTHORISATION.
+                  - ORIGEM_FIDO_INVALIDA: O valor contido no campo ```fidoAssertion.response.clientDataJSON.origin``` não pode ser verificado.
                   - RISCO: Validação síncrona dos sinais de risco impediram a ativação do consentimento.                  
                   - FALTAM_SINAIS_OBRIGATORIOS_DA_PLATAFORMA: Os sinais obrigatórios para a plataforma do usuário não foram enviados em sua totalidade.
                   - CONTA_DEBITO_DIVERGENTE_CONSENTIMENTO_VINCULO: A conta de débito informada pelo iniciador não condiz com a conta de débito vinculada ao dispositivo.
@@ -1200,6 +1202,7 @@ components:
 
                   - STATUS_VINCULO_INVALIDO: Status do vínculo de conta inválido.
                   - STATUS_CONSENTIMENTO_INVALIDO: Status do consentimento inválido.
+                  - ORIGEM_FIDO_INVALIDA: "Origin" não pode ser verificada.
                   - RISCO: Validação síncrona dos sinais de risco impediram a ativação do consentimento.
                   - FALTAM_SINAIS_OBRIGATORIOS_DA_PLATAFORMA: Falta de sinais obrigatórios para a plataforma do usuário.
                   - CONTA_DEBITO_DIVERGENTE_CONSENTIMENTO_VINCULO: A conta de débito informada pelo iniciador não condiz com a conta de débito vinculada ao dispositivo.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ info:
     O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo de validação durante a autorização do consentimento através desta API.   
     Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no consentimento de Pix Automático.
   
-  version: 2.2.0-rc.3
+  version: 2.2.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -1220,6 +1220,7 @@ components:
                   - STATUS_VINCULO_INVALIDO: O vínculo de conta não possui status AUTHORISED.
                   - STATUS_CONSENTIMENTO_INVALIDO: O consentimento de pagamentos não possui status AWAITING_AUTHORISATION.
                   - RISCO: Validação síncrona dos sinais de risco impediram a ativação do consentimento.
+                  - ORIGEM_FIDO_INVALIDA: O valor contido no campo [response.clientDataJSON.origin](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson) não pode ser verificado.
                   - FALTAM_SINAIS_OBRIGATORIOS_DA_PLATAFORMA: Os sinais obrigatórios para a plataforma do usuário não foram enviados em sua totalidade.
                   - CONTA_DEBITO_DIVERGENTE_CONSENTIMENTO_VINCULO: A conta de débito informada pelo iniciador não condiz com a conta de débito vinculada ao dispositivo.
                   - PARAMETRO_NAO_INFORMADO: Parâmetro [nome_campo] obrigatório não informado.


### PR DESCRIPTION
### Contexto

Durante a implementação da PJR-106 (“Proposta para adicionar novo endpoint para autorização de consentimentos recorrentes de Pix Automático”), e a partir da comparação com as informações presentes no header da API relacionadas ao campo ORIGIN URL, a DTO identificou a ausência do erro 422, representativo à falha nessa validação por parte da instituição detentora 
▪ Dessa forma, Squad e DTO entendem que o erro deve ser adicionado ao endpoint, permitindo que a instituição detentora ecoe o erro correto em casos de falha nessa validação  

### Descrição

No endpoint POST /recurring-consents/{recurringConsentId}/authorise,   
adicionar um novo item ao código de erro HTTP 422:  
– Incluir no domínio do enum /data/errors[]/code:  
▫ ORIGEM_FIDO_INVALIDA  
– Incluir na descrição do campo /data/errors[]/code e /data/errors[]/detail:  
▫ ORIGEM_FIDO_INVALIDA: O valor contido no campo   
fidoAssertion.response.clientDataJSON.origin não pode ser verificado  
– Incluir na descrição do campo /data/errors[]/title:  
▫ ORIGEM_FIDO_INVALIDA: "Origin" não pode ser verificada  