### PR TITLE
[Squad Jornada] PJR140 - Enrollments - 2.2.0: API Vínculo de dispositivo – Proposta para adicionar um novo escopo para geração de tokens de acesso nos endpoints da API

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ info:
     O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo de validação durante a autorização do consentimento através desta API.   
     Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no consentimento de Pix Automático.
   
-  version: 2.2.0-rc.3
+  version: 2.2.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -96,8 +96,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2ClientCredentials:
-            - payments
+        - OAuth2ClientCredentialsPayments: [payments]                    # Opção 1
+        - OAuth2ClientCredentialsRecurringPayments: [recurring-payments]         # Opção 2  
+        - OAuth2ClientCredentialsPaymentsAndRecurring: [payments, recurring-payments] # Opção 3
   '/enrollments/{enrollmentId}':
     get:
       tags:
@@ -138,8 +139,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2ClientCredentials:
-            - payments
+        - OAuth2ClientCredentialsPayments: [payments]                    # Opção 1
+        - OAuth2ClientCredentialsRecurringPayments: [recurring-payments]         # Opção 2  
+        - OAuth2ClientCredentialsPaymentsAndRecurring: [payments, recurring-payments] # Opção 3
     patch:
       tags:
         - Vínculo de dispositivo
@@ -261,8 +263,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2ClientCredentials:
-            - payments
+        - OAuth2ClientCredentialsPayments: [payments]                    # Opção 1
+        - OAuth2ClientCredentialsRecurringPayments: [recurring-payments]         # Opção 2  
+        - OAuth2ClientCredentialsPaymentsAndRecurring: [payments, recurring-payments] # Opção 3
   '/enrollments/{enrollmentId}/fido-registration-options':
     post:
       tags:
@@ -316,10 +319,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2AuthorizationCode:
+        - OAuth2AuthorizationCodePaymentsAndRecurring:
             - openid
             - 'enrollment:enrollmentId'
             - payments
+            - recurring-payments
+        - OAuth2AuthorizationCodePayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - payments
+        - OAuth2AuthorizationCodeRecurringPayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
   '/enrollments/{enrollmentId}/fido-registration':
     post:
       tags:
@@ -375,9 +387,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2AuthorizationCode:
+        - OAuth2AuthorizationCodePayments:
             - openid
             - 'enrollment:enrollmentId'
+            - payments
+        - OAuth2AuthorizationCodeRecurringPayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
+        - OAuth2AuthorizationCodePaymentsAndRecurring:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
             - payments
   /enrollments/{enrollmentId}/fido-sign-options:
     post:
@@ -481,8 +502,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2ClientCredentials:
-            - payments
+        - OAuth2ClientCredentialsPayments: [payments]                    # Opção 1
+        - OAuth2ClientCredentialsRecurringPayments: [recurring-payments]         # Opção 2  
+        - OAuth2ClientCredentialsPaymentsAndRecurring: [payments, recurring-payments] # Opção 3
   /enrollments/{enrollmentId}/risk-signals:
     post:
       tags:
@@ -538,8 +560,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2ClientCredentials:
-            - payments
+        - OAuth2ClientCredentialsPayments: [payments]                    # Opção 1
+        - OAuth2ClientCredentialsRecurringPayments: [recurring-payments]         # Opção 2  
+        - OAuth2ClientCredentialsPaymentsAndRecurring: [payments, recurring-payments] # Opção 3
   /consents/{consentId}/authorise:
     post:
       tags:
@@ -600,11 +623,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2AuthorizationCode:
-          - openid
-          - 'enrollment:enrollmentId'
-          - payments
-          - nrp-consents
+        - OAuth2AuthorizationCodePayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - payments
+        - OAuth2AuthorizationCodeRecurringPayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
+        - OAuth2AuthorizationCodePaymentsAndRecurring:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
+            - payments
   /recurring-consents/{recurringConsentId}/authorise:
     post:
       tags:
@@ -660,11 +691,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseError'
       security:
-        - OAuth2AuthorizationCode:
-          - openid
-          - 'enrollment:enrollmentId'
-          - recurring-payments
-          - nrp-consents
+        - OAuth2AuthorizationCodePayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - payments
+        - OAuth2AuthorizationCodeRecurringPayments:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
+        - OAuth2AuthorizationCodePaymentsAndRecurring:
+            - openid
+            - 'enrollment:enrollmentId'
+            - recurring-payments
+            - payments
 components:
   headers:
     xFapiInteractionId:
@@ -2640,25 +2679,71 @@ components:
     OpenId:
       type: openIdConnect
       openIdConnectUrl: 'https://auth.mockbank.poc.raidiam.io/.well-known/openid-configuration'
-    OAuth2ClientCredentials:
+    OAuth2ClientCredentialsPayments:
       type: oauth2
       description: |
-        Fluxo OAuth necessário para que a iniciadora possa iniciar pagamentos. Requer o processo de redirecionamento e autenticação do usuário.  
-        Apenas pagamentos iniciados pela mesma iniciadora podem ser consultados ou cancelados através de modelo client credentials.
+        Fluxo OAuth necessário para que a iniciadora possa iniciar transações na API Pagamentos. Deve ser utilizado quando a ITP operar apenas na API Pagamentos.
+        Apenas transações iniciadas pela mesma iniciadora podem ser consultados ou cancelados através de modelo client credentials.
       flows:
         clientCredentials:
           tokenUrl: 'https://authserver.example/token'
           scopes:
             payments: Escopo necessário para acesso à API Payment Initiation.
-    OAuth2AuthorizationCode:
+    OAuth2ClientCredentialsRecurringPayments:
       type: oauth2
-      description: Fluxo OAuth necessário para que a iniciadora possa iniciar pagamentos. Requer o processo de redirecionamento e autenticação do usuário.
+      description: |
+        Fluxo OAuth necessário para que a iniciadora possa iniciar transações na API Pagamentos Automáticos. Deve ser utilizado quando a ITP operar apenas na API Pagamentos Automáticos.
+        Apenas transações iniciadas pela mesma iniciadora podem ser consultados ou cancelados através de modelo client credentials.
+      flows:
+        clientCredentials:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            recurring-payments: Escopo necessário para acesso à API Automatic Payments.
+    OAuth2ClientCredentialsPaymentsAndRecurring:
+      type: oauth2
+      description: |
+        Fluxo OAuth necessário para que a iniciadora possa iniciar transações nas API Pagamentos e Pagamentos Automáticos.  Deve ser utilizado quando a ITP operar nas APIs Pagamentos e Pagamentos Automáticos.
+        Apenas transações iniciadas pela mesma iniciadora podem ser consultados ou cancelados através de modelo client credentials.
+      flows:
+        clientCredentials:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            payments: Escopo necessário para acesso à API Payment Initiation.
+            recurring-payments: Escopo necessário para acesso à API Automatic Payments.
+    OAuth2AuthorizationCodePaymentsAndRecurring:
+      type: oauth2
+      description: Fluxo OAuth necessário para que a iniciadora possa iniciar pagamentos. Deve ser utilizado quando a ITP operar nas APIs Pagamentos e Pagamentos Automáticos.
       flows:
         authorizationCode:
           authorizationUrl: 'https://authserver.example/token'
           tokenUrl: 'https://authserver.example/token'
           scopes:
             payments: Escopo necessário para acesso à API Payment Initiation.
+            recurring-payments: Escopo necessário para acesso à API Automatic Payments.
+            openid: Indica que a autorização está sendo realizada utilizando o protocolo definido pela openid.
+            'enrollment:enrollmentId': Permite realizar atualização de um registro com a permissão do cliente.      
+            nrp-consents: Consentimento para pagamentos sem redirecionamento.
+    OAuth2AuthorizationCodePayments:
+      type: oauth2
+      description: Fluxo OAuth necessário para que a iniciadora possa iniciar pagamentos. Deve ser utilizado quando a ITP operar apenas na API Pagamentos.
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://authserver.example/token'
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            payments: Escopo necessário para acesso à API Payment Initiation.
+            recurring-payments: Escopo necessário para acesso à API Automatic Payments.
+            openid: Indica que a autorização está sendo realizada utilizando o protocolo definido pela openid.
+            'enrollment:enrollmentId': Permite realizar atualização de um registro com a permissão do cliente.      
+            nrp-consents: Consentimento para pagamentos sem redirecionamento.
+    OAuth2AuthorizationCodeRecurringPayments:
+      type: oauth2
+      description: Fluxo OAuth necessário para que a iniciadora possa iniciar pagamentos. Deve ser utilizado quando a ITP operar apenas na API Pagamentos Automáticos.
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://authserver.example/token'
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
             recurring-payments: Escopo necessário para acesso à API Automatic Payments.
             openid: Indica que a autorização está sendo realizada utilizando o protocolo definido pela openid.
             'enrollment:enrollmentId': Permite realizar atualização de um registro com a permissão do cliente.      


### PR DESCRIPTION
### Contexto
▪ Foi identificado, através do ticket #118088, que a maioria dos endpoints da API não estão preparados para receber solicitações de clientes que possuem acesso ou que decidiram por utilizar apenas o escopo “recurring-payments”  
▪ Dessa forma, com o intuito de não onerar instituições que, de maneira legítima, decidiram operar apenas um dos produtos e declararam unicamente esse escopo no DCR/DCM, faz-se necessária a inclusão da declaração do escopo aos demais endpoints  de acesso ao serviço

### Descrição
▪ Nos endpoints POST /enrollments, GET /enrollments/{enrollmentId} e PATCH   /enrollments/{enrollmentId}:  
– Adicionar no securitySchema atual dos endpoints a possibilidade de geração de   tokens do tipo clientCredentials com escopo “recurring-payments”  
▪ Nos endpoints POST /enrollments/{enrollmentId}/fido-registration-options, POST   /enrollments/{enrollmentId}/fido-registration, POST   /enrollments/{enrollmentId}/fido-sign-options, POST   /enrollments/{enrollmentId}/risk-signals:  
– Adicionar no securitySchema atual dos endpoints a possibilidade de geração de   tokens do tipo authorizationCode com escopo “recurring-payments”  