### PR TITLE
[Squad Jornada] PJR125 - Enrollments - 2.2.0: API Vínculo de dispositivo –  Proposta para ajustar a descrição do objeto de sinais de risco

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -704,6 +704,7 @@ paths:
             - 'enrollment:enrollmentId'
             - recurring-payments
             - payments
+
 components:
   headers:
     xFapiInteractionId:
@@ -1351,7 +1352,10 @@ components:
       properties:
         data:
           type: object
-          description: Informa a integridade do dispositivo e app
+          description: |
+            Conjunto de sinais extraídos do dispositivo do usuário para ativação do consentimento de pagamento.  
+            Em casos de autenticação cross-platform, deve ser considerado o dispositivo utilizado para acesso ao canal da instituição, não o autenticador externo utilizado para assinatura.   
+            A obrigatoriedade das informações variam de acordo com a plataforma utilizada.  
           required:
             - deviceId
             - osVersion
@@ -1567,8 +1571,9 @@ components:
                 - screenDimensions
                 - accountTenure
               description: |
-                Conjunto de sinais extraídos do dispositivo do usuário para ativação do consentimento de pagamento.
-                A obrigatoriedade das informações variam de acordo com a plataforma utilizada.
+                Conjunto de sinais extraídos do dispositivo do usuário para ativação do consentimento de pagamento.  
+                Em casos de autenticação cross-platform, deve ser considerado o dispositivo utilizado para acesso ao canal da instituição, não o autenticador externo utilizado para assinatura.   
+                A obrigatoriedade das informações variam de acordo com a plataforma utilizada.  
               properties:
                 deviceId:
                   type: string


### PR DESCRIPTION
### Contexto
Após discussão relacionada a sinais de risco em agendas, Squad e DTO optaram por esclarecer exatamente qual dispositivo está sendo referenciado nos sinais de risco, especialmente nos casos de autenticação cross-platform, em que o dispositivo autenticador pode não ser o mesmo utilizado pelo cliente para acessar a aplicação do ITP (ex.: YubiKey, smartphone etc.)  

### Descrição
Na mensagem de requisição dos endpoints POST /consents/{consentId}/authorise e POST   /recurring-consents/{recurringConsentId}/authorise:  
– Ajustar a descrição objeto que detém os sinais de risco:  
▫ De: Conjunto de sinais extraídos do dispositivo do usuário para ativação do consentimento de   pagamento. A obrigatoriedade das informações variam de acordo com a plataforma utilizada.  
▫ Para: Conjunto de sinais extraídos do dispositivo do usuário para ativação do consentimento   de pagamento. Em casos de autenticação cross-platform, deve ser considerado o dispositivo   utilizado para acesso ao canal da instituição, não o autenticador externo utilizado para   assinatura.   A obrigatoriedade das informações variam de acordo com a plataforma utilizada.  
▪ Na mensagem de requisição do endpoint POST /enrollments/{enrollmentId}/risk-signals:  
– Ajustar a descrição do objeto que detém os sinais de risco:  
▫ De: Informa a integridade do dispositivo e app.  
▫ Para: Conjunto de sinais extraídos do dispositivo do usuário para ativação do vínculo. Em casos   de autenticação cross-platform, deve ser considerado o dispositivo utilizado para acesso ao   canal da instituição, não o autenticador externo utilizado para assinatura.   A obrigatoriedade das informações variam de acordo com a plataforma utilizada.  