### PR TITLE
[Squad Jornada] PJR138 - Enrollments - 2.2.0: API Vínculo de dispositivo –  Proposta para adicionar os códigos de erro HTTP 415 e HTTP 504 em endpoints

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -87,6 +87,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollment'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -130,6 +132,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -250,10 +254,14 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '422':
           $ref: '#/components/responses/UnprocessableEntityEnrollmentCancel'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -310,6 +318,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentFidoRegistrationOptions'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -378,6 +388,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentFidoRegistration'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -493,6 +505,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentFidoSignOptions'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -551,6 +565,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentRiskSignals'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -614,6 +630,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityConsentsAuthorization'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -678,10 +696,14 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '422':
           $ref: '#/components/responses/UnprocessableEntityRecurringConsentsAuthorization'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -2753,6 +2775,8 @@ components:
             'enrollment:enrollmentId': Permite realizar atualização de um registro com a permissão do cliente.      
             nrp-consents: Consentimento para pagamentos sem redirecionamento.
   responses:
+    GatewayTimeout:
+      description: A requisição não foi atendida dentro do tempo limite estabelecido.  
     BadRequest:
       description: 'A requisição foi malformada, omitindo atributos obrigatórios, seja no payload ou através de atributos na URL.'
       content:


### PR DESCRIPTION
### Contexto
▪ Durante a implementação da PJR-106  (“Proposta para adicionar novo endpoint para autorização de consentimentos recorrentes de Pix Automático”), e com base na versão 7.0.0 do manual de APIs do Open Finance (IN n° 615), a DTO identificou um ponto de correção e um ponto de melhoria na especificação da API Vínculo de dispositivos  
▪ O Manual determina que as APIs devem contemplar o erro HTTP 504, considerando a possibilidade de ocorrência de um timeout nas requisições  
▪ Além disso, em alinhamento às boas práticas e ao HATEOAS do framework REST, a DTO propõe a adição do erro HTTP 415, com o objetivo de facilitar a interpretação de problemas de integração para consumidores dos serviços  

### Descrição
▪ Adicionar o código de erro HTTP 504 em todos os endpoints da API, com as seguintes  propriedades:  
– Descrição: A requisição não foi atendida dentro do tempo limite estabelecido.  
– MediaType: Não especificado  
– Response body: Não especificado  
▪ Nos endpoints PATCH /enrollments/{enrollmentId} e POST /recurring-consents/{recurringConsentId}/authorise, adicionar o código de erro HTTP 415, com as   seguintes propriedades:  
– Descrição: O formato do payload não é um formato suportado.  
– MediaType: application/json; charset=utf-8  
– Response body:  
▫ /data  
▫ data/errors[]  
▫ data/errors[].code  
▫ data/errors[].detail  