### PR TITLE
[Squad Jornada] PJR141 - Enrollments - 2.2.0: API Vínculo de dispositivo –  Proposta para adequar a regra de preenchimento dos sinais de risco para aplicações não nativas de Android ou iOS

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -87,6 +87,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollment'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -130,6 +132,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -250,10 +254,14 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '422':
           $ref: '#/components/responses/UnprocessableEntityEnrollmentCancel'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -310,6 +318,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentFidoRegistrationOptions'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -378,6 +388,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentFidoRegistration'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -493,6 +505,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentFidoSignOptions'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -551,6 +565,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityEnrollmentRiskSignals'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -614,6 +630,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityConsentsAuthorization'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -678,10 +696,14 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '422':
           $ref: '#/components/responses/UnprocessableEntityRecurringConsentsAuthorization'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -1373,7 +1395,7 @@ components:
               description: |
                 Indica se o dispositivo atualmente está com permissão de “root”.
  
-                [Restrição] Campos de envio obrigatório quando o sistema operacional utilizado pelo usuário durante a vinculação de conta ou realização do pagamento for Android ou iOS.
+                [Restrição] Campos de envio obrigatório quando o usuário utilizar uma aplicação nativa para Android ou iOS.  
               example: false
             screenBrightness:
               type: number
@@ -1385,7 +1407,7 @@ components:
 
                [iOS] O valor é ponto flutuante entre “0.0” e “1.0”. Referência no [link](https://developer.apple.com/documentation/uikit/uiscreen/).
 
-               [Restrição] Campos de envio obrigatório quando o sistema operacional utilizado pelo usuário durante a vinculação de conta ou realização do pagamento for Android ou iOS.
+                [Restrição] Campos de envio obrigatório quando o usuário utilizar uma aplicação nativa para Android ou iOS.  
               example: 255
             elapsedTimeSinceBoot:
               type: integer
@@ -1397,7 +1419,7 @@ components:
 
                 [iOS] Informação obtida através do [link](https://developer.apple.com/documentation/kernel/kern/).
 
-                [Restrição] Campos de envio obrigatório quando o sistema operacional utilizado pelo usuário durante a vinculação de conta ou realização do pagamento for Android ou iOS.
+                [Restrição] Campos de envio obrigatório quando o usuário utilizar uma aplicação nativa para Android ou iOS.  
               example: 6356027
             osVersion:
               type: string
@@ -2753,6 +2775,8 @@ components:
             'enrollment:enrollmentId': Permite realizar atualização de um registro com a permissão do cliente.      
             nrp-consents: Consentimento para pagamentos sem redirecionamento.
   responses:
+    GatewayTimeout:
+      description: A requisição não foi atendida dentro do tempo limite estabelecido.  
     BadRequest:
       description: 'A requisição foi malformada, omitindo atributos obrigatórios, seja no payload ou através de atributos na URL.'
       content:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1604,7 +1604,7 @@ components:
                   description: |
                     Indica se o dispositivo atualmente está com permissão de “root”.
 
-                    [Restrição] Campos de envio obrigatório quando o sistema operacional utilizado pelo usuário durante a vinculação de conta ou realização do pagamento for Android ou iOS.
+                    [Restrição] Campos de envio obrigatório quando o usuário utilizar uma aplicação nativa para Android ou iOS.  
                 screenBrightness:
                   type: number
                   format: double
@@ -1615,7 +1615,7 @@ components:
 
                     [iOS] O valor é ponto flutuante entre “0.0” e “1.0”. Referência no [link](https://developer.apple.com/documentation/uikit/uiscreen/).
 
-                    [Restrição] Campos de envio obrigatório quando o sistema operacional utilizado pelo usuário durante a vinculação de conta ou realização do pagamento for Android ou iOS.
+                    [Restrição] Campos de envio obrigatório quando o usuário utilizar uma aplicação nativa para Android ou iOS.  
                 elapsedTimeSinceBoot:
                   type: integer
                   format: int64
@@ -1626,7 +1626,7 @@ components:
 
                     [iOS] Informação obtida através do [link](https://developer.apple.com/documentation/kernel/kern/).
 
-                    [Restrição] Campos de envio obrigatório quando o sistema operacional utilizado pelo usuário durante a vinculação de conta ou realização do pagamento for Android ou iOS.
+                    [Restrição] Campos de envio obrigatório quando o usuário utilizar uma aplicação nativa para Android ou iOS.  
                 osVersion:
                   type: string
                   description: |


### PR DESCRIPTION
### Contexto
▪ O produto Pagamentos Automáticos passou por melhorias recentes, incluindo ajustes nas orientações relacionadas ao uso dos sinais de risco trafegados no fluxo  
▪ Para garantir consistência entre os fluxos, esse ajuste também precisa ser refletido na Jornada Sem Redirecionamento, de modo a uniformizar os comportamentos adotados na liquidação, independentemente do caminho utilizado pelo usuário  
▪ A DTO identificou que a restrição atual — que limita o envio desses sinais ao sistema operacional — não é adequada, pois apenas aplicações nativas conseguem coletá-los, o que contraria o apontamento do ticket #127862 sobre a obrigatoriedade desses sinais para apps não nativos (Android ou iOS)  
▪ Assim, torna-se necessário ajustar a descrição de alguns campos para refletir corretamente esse entendimento e garantir alinhamento entre fluxos e tipos de aplicação  

### Descrição

Na mensagem de requisição dos endpoints POST /enrollments/{enrollmentId}/risk-signals, POST /consents /{consentId} /authorise, e POST /recurring-consents/{recurringConsentId} /authorise  
– Ajustar a [RESTRIÇÃO] dos seguintes campos presentes no objeto “/data/riskSignals”:  
▫ isRootedDevice, screenBrightness, elapsedTimeSinceBoot:  
- De: Campos de envio obrigatório quando o sistema operacional utilizado   
pelo usuário durante a vinculação de conta ou realização do pagamento for   
Android ou iOS.  
- Para: Campos de envio obrigatório quando o usuário utilizar uma aplicação   
nativa para Android ou iOS.  