### PR TITLE
[Squad Jornada] PJR156 - Enrollments - 2.3.0: API Vínculo de dispositivo – Proposta para ajustar a regra de preenchimento do campo user.id

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ info:
     O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo de validação durante a autorização do consentimento através desta API.   
     Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no consentimento de Pix Automático.
   
-  version: 2.2.0
+  version: 2.3.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2218,8 +2218,8 @@ components:
         id:
           type: string
           description: |
-            Identificador único do usuário sob registro em formato base64. A conversão deste valor para o formato original (BufferSource ou ArrayBuffer) não deve ultrapassar 64 bytes. 
-            O identificador único deve ser opaco, ou seja, não deve carregar dados pessoais sobre o usuário, por exemplo (não exaustivo) um UUID RFC4122 cumpre com os requisitos desse campo
+            Identificador único do usuário sob registro em formato base64. A conversão deste valor para o formato original (BufferSource ou ArrayBuffer) não deve ultrapassar 64 bytes.
+            O identificador único deve ser criado a partir de um UUID RFC4122 convertido para base64url. É vedada a reutilização do valor em vínculos distintos
         name:
           type: string
           description: Identificador do usuário human-readable.


### PR DESCRIPTION
### Contexto
• Foi apresentado ao grupo um material criado pela cadeira 2.3 relacionado ao modelo de preenchimento do campo data.user.id, visto que, a depender da forma que esse preenchimento é realizado, ocorre a sobrescriçãodas credenciais dentro do dispositivo, inutilizando-as para os usuários de sistemas operacionais Apple.
• Dessa forma, para evitar que um novo vinculo sobrescreva o anterior existente nesse sistema operacional, faz-se necessário ajustar a forma que o fido-server atribui valores de user.id, padronizando-o com base em uma informação única e imutável em todo o processo, um UUID.

### Descrição
Na mensagem de resposta de sucesso do endpointPOST ​/enrollments​/{enrollmentId}​/fido
registration-options:
▪ Ajustar descrição do campo data.user.id
▪ DE: Identificador único do usuário sob registro em formato base64. A conversão deste 
valor para o formato original (BufferSourceou ArrayBuffer) não deve ultrapassar 64 bytes. 
O identificador único deve ser opaco, ou seja, não deve carregar dados pessoais sobre o 
usuário, por exemplo (não exaustivo) um UUID RFC4122 cumpre com os requisitos desse 
campo
▪ PARA: Identificador único do usuário sob registro em formato base64. A conversão deste 
valor para o formato original (BufferSourceou ArrayBuffer) não deve ultrapassar 64 bytes. 
O identificador único deve ser criado a partir de um UUID RFC4122 convertido para 
base64url. É vedada a reutilização do valor em vínculos distintos