### PR TITLE
[Squad Jornada] PJR157 - Enrollments - 2.3.0: API Vinculo de Dispositivo - Proposta para criar mecanismo de confiança sobre domínio servidos pela ITP nos fluxos de vinculação e pagamento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7,11 +7,14 @@ info:
     
     ## Validação de origin nos endpoints FIDO
 
-    Durante o cadastro do cliente (DCR/DCM), o software statement assertion possui um atributo nomeado software_origin_uris. 
-    Esse atributo armazena as origens permitidas para utilização do protocolo FIDO. 
-    Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve ser realizada a verificação se a origin do mesmo está contida no software_origin_uris informado no momento do DCR/DCM. 
+    Durante o cadastro do cliente (DCR/DCM), o software statement assertion possui o atributo software_origin_uris, que armazena as origens autorizadas para utilização do protocolo FIDO pela iniciadora, tanto origens próprias quanto origens de páginas top-level nas quais a iniciadora opera embarcada via iframe cross-origin.   
 
-    Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária realização de um novo processo de DCM com as detentoras.
+    - Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), a detentora deve:  
+    &ensp; ▪ Extrair origin do clientDataJSON e verificar que está contido em software_origin_uris.   
+    &ensp; ▪ Quando o campo crossOrigin do clientDataJSON for true, extrair adicionalmente o topOrigin e verificar que também está contido em software_origin_uris.  
+    &ensp; ▪ Quando crossOrigin for false ou estiver ausente, o campo topOrigin não deve ser avaliado.  
+    &ensp; ▪ A ausência de qualquer uma das origens aplicáveis em software_origin_uris deve resultar em rejeição com código ORIGEM_FIDO_INVALIDA.  
+    - Caso a iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária a realização de um novo processo de DCM com as detentoras
 
     ## Sobre os limites do dispositivo vinculado no Pix Automático
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ info:
     O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo de validação durante a autorização do consentimento através desta API.   
     Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no consentimento de Pix Automático.
   
-  version: 2.2.0
+  version: 2.3.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto
• O ecossistema Open Finance Brasil tem registrado adoção crescente de modelos em que iniciadoras de pagamento operam embarcadas, via iframe cross-origin, em páginas de prestadores de serviço tomadores (tipicamente e-commerces, ERPs e gateways que terceirizam a iniciação de pagamento)  
• A especificação vigente da API Enrollments, ao validar somente o campo origin do clientDataJSON  contra software_origin_uris, não disciplina esse cenário e deixa o campo topOrigin sem tratamento normativo  
• Esta proposta visa ampliar a semântica de software_origin_uris para abranger origens de páginas top-level autorizadas, viabilizando o modelo embarcado com garantias equivalentes às do cenário top-level  


### Descrição

Ajustar o texto do header da API, dentro do tópico “Validação de origin nos endpoints FIDO”:  
▪ DE: Durante o cadastro do cliente (DCR/DCM), o software statement assertion possui um   
atributo nomeado software_origin_uris. Esse atributo armazena as origens permitidas para   
utilização do protocolo FIDO. Nas chamadas que possuem o argumento clientDataJSON  
(fido-registration e authorise), o atributo origin deve ser extraído do clientDataJSON e deve   
ser realizada a verificação se a origin do mesmo está contida no software_origin_uris   
informado no momento do DCR/DCM.  
Caso a instituição iniciadora altere ou inclua o valor do atributo software_origin_uris, será   
necessária realização de um novo processo de DCM com as detentoras.  
▪ PARA: Durante o cadastro do cliente (DCR/DCM), o software statement assertion possui o   
atributo software_origin_uris, que armazena as origens autorizadas para utilização do   
protocolo FIDO pela iniciadora, tanto origens próprias quanto origens de páginas top-level   
nas quais a iniciadora opera embarcada via iframe cross-origin.  
▪ Nas chamadas que possuem o argumento clientDataJSON (fido-registration e authorise), a   
detentora deve:  
▪ Extrair origin do clientDataJSON e verificar que está contido em software_origin_uris.  
▪ Quando o campo crossOrigin do clientDataJSON for true, extrair adicionalmente o   
topOrigin e verificar que também está contido em software_origin_uris.  
▪ Quando crossOrigin for false ou estiver ausente, o campo topOrigin não deve ser   
avaliado.  
▪ A ausência de qualquer uma das origens aplicáveis em software_origin_uris deve   
resultar em rejeição com código ORIGEM_FIDO_INVALIDA.  
▪ Caso a iniciadora altere ou inclua o valor do atributo software_origin_uris, será necessária a   
realização de um novo processo de DCM com as detentoras. 