### PR TITLE
[Squad Jornada] PJR159 - Enrollments - 2.3.0: API Vinculo de Dispositivo - Proposta para alterar a descrição do campo transactionLimit

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ info:
     O valor mínimo definido pelo recebedor no âmbito do Pix Automático também não é alvo de validação durante a autorização do consentimento através desta API.   
     Por fim, os limites do pagamento das recorrências a ser considerado são os definidos no consentimento de Pix Automático.
   
-  version: 2.2.0
+  version: 2.3.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -2554,10 +2554,9 @@ components:
               pattern: '^((\d{1,16}\.\d{2}))$'
               example: '100000.12'
               description: |
-                Valor máximo, por transação, admitido para este vínculo de conta. Este limite não garante a autorização de iniciações de pagamento;
-                servindo como referência para a iniciadora evitar a criação de consentimentos de valores tais que, garantidamente, não serão autorizados.
-
-                [Restrição] Campo de preenchimento obrigatório pelos participantes quando o campo `status` for preenchido com os valores `AUTHORISED` ou `AWAITING_ENROLLMENT`.
+                Valor máximo, por transação, admitido para este vínculo de conta. Este limite não garante a autorização de iniciações de pagamento; servindo como referência para a iniciadora evitar a criação de consentimentos de valores tais que, garantidamente, não serão autorizados.   
+                Os limites transacionais estabelecidos pela instituição detentora da conta permanecem aplicáveis, independentemente do preenchimento deste campo.   
+                [Restrição] Campo de preenchimento obrigatório quando: houver definição de limite transacional pelo usuário durante a autorização ou edição do vínculo  
             dailyLimit:
               type: string
               minLength: 4


### PR DESCRIPTION
### Contexto

A IN 746, publicada pelo BCB em 15/06/2026, estabelece que os limites transacionais na Jornada sem Redirecionamento não terão como teto máximo o valor de R$500,00, permitindo que o usuário defina seu próprio limite até o teto Pix do seu banco.  
▪ Com a entrada em vigor prevista para 1º de outubro de 2026, a Squad JSR precisa promover as devidas atualizações na API de Vínculo para adequar a obrigatoriedade de envio e a descrição do campo transactionLimit, garantindo conformidade com a normativa e evitando impactos nas integrações das instituições participantes. 


### Descrição

• Ajustar a descrição do campo /data/transactionLimit:  
DE:   
• Valor máximo, por transação, admitido para este vínculo de conta. Este limite não garante a autorização de iniciações de   
pagamento; servindo como referência para a iniciadora evitar a criação de consentimentos de valores tais que, garantidamente,  
não serão autorizados. [Restrição] Campo de preenchimento obrigatório pelos participantes quando o campo `status` for   
preenchido com os valores `AUTHORISED` ou `AWAITING_ENROLLMENT`.  
PARA:  
• Valor máximo, por transação, admitido para este vínculo de conta. Este limite não garante a autorização de iniciações de   
pagamento; servindo como referência para a iniciadora evitar a criação de consentimentos de valores tais que, garantidamente,  
não serão autorizados. Os limites transacionais estabelecidos pela instituição detentora da conta permanecem aplicáveis,   
independentemente do preenchimento deste campo. [Restrição] Campo de preenchimento obrigatório quando: houver   
definição de limite transacional pelo usuário durante a autorização ou edição do vínculo  